### PR TITLE
Fix AE badges & Oort paper name

### DIFF
--- a/source/_data/SymbioticLab.bib
+++ b/source/_data/SymbioticLab.bib
@@ -498,8 +498,8 @@ In this work, we study a slightly different model of coflow scheduling in genera
   publist_link = {slides || salus-mlsys20-talk.pptm},
   publist_link = {poster || salus-mlsys20-poster.pdf},
   publist_badge = {Artifacts Available},
-  publist_badge = {Artifacts Evaluated Functional},
-  publist_badge = {Results Replicated},
+  publist_badge = {Artifacts Functional},
+  publist_badge = {Results Reproduced},
   publist_topic = {Systems + AI},
   publist_abstract = {
     Unlike traditional resources such as CPU or the network, modern GPUs do not natively support
@@ -567,9 +567,9 @@ In this work, we study a slightly different model of coflow scheduling in genera
   publist_link = {paper || netlock-sigcomm20.pdf},
   publist_topic = {Datacenter Networking},
   publist_topic = {Disaggregation},
-  publist_badge = {Artifact Available},
-  publist_badge = {Artifact Functional},
-  publist_badge = {Artifact Reusable},
+  publist_badge = {Artifacts Available},
+  publist_badge = {Artifacts Functional},
+  publist_badge = {Results Reproduced},
   publist_abstract = {
   
     Lock managers are widely used by distributed systems. Traditional centralized lock managers can easily support policies between multiple users using global knowledge, but they suffer from low performance. In contrast, emerging decentralized approaches are faster but cannot provide flexible policy support. Furthermore, performance in both cases is limited by the server capability.
@@ -659,7 +659,7 @@ In this work, we study a slightly different model of coflow scheduling in genera
 @InProceedings{oort:osdi21,
   author    = {Fan Lai and Xiangfeng Zhu and Harsha V. Madhyastha and Mosharaf Chowdhury},
   booktitle = {USENIX OSDI},
-  title     = {Efficient Federated Learning via Guided Participant Selection},
+  title     = {Oort: Efficient Federated Learning via Guided Participant Selection},
   year      = {2021},
 
   publist_confkey = {OSDI'21},


### PR DESCRIPTION
To keep AE badges consistent, we are going to use ("Artifacts Available", "Artifacts Functional", and "Results Reproduced") for all papers. 