### PR TITLE
Fix Aequitas order in the publication list 

### DIFF
--- a/source/publications/index.md
+++ b/source/publications/index.md
@@ -107,7 +107,7 @@ venues:
     occurrences:
     - key: SIGCOMM'22
       name: The 2022 ACM SIGCOMM Conference
-      date: 2021-08-22
+      date: 2022-08-22
       url: https://conferences.sigcomm.org/sigcomm/2022/
       acceptance: 19.57%
     - key: SIGCOMM'21


### PR DESCRIPTION
Now it appears in the year 2021 instead of 2022 due to a type in the conference start date