### PR TITLE
Add excerpt to each page to set `og:description`

### DIFF
--- a/source/cluster/index.md
+++ b/source/cluster/index.md
@@ -1,6 +1,7 @@
 ---
 title: cluster
 date: 2023-09-05 10:40:00
+excerpt: "Introducing the powerful SymbioticLab cluster!"
 ---
 
 ![server](server.jpg)

--- a/source/funding/index.md
+++ b/source/funding/index.md
@@ -1,6 +1,7 @@
 ---
 title: Funding
 date: 2020-08-18 12:08:53
+excerpt: "Our current & past sponsors"
 ---
 
 <style>

--- a/source/people/index.md
+++ b/source/people/index.md
@@ -1,6 +1,7 @@
 ---
 title: People
 date: 2023-04-16 00:44:00
+excerpt: "SymbioticLab current & past members"
 ---
 
 ## Faculty

--- a/source/publications/index.md
+++ b/source/publications/index.md
@@ -3,6 +3,7 @@ title: Publications
 date: 2020-07-22 23:10:02
 publist: true
 mathjax: true
+excerpt: "A list of publications from SymbioticLab"
 ---
 {% publist SymbioticLab %}
 version: 2

--- a/source/research/index.md
+++ b/source/research/index.md
@@ -1,6 +1,7 @@
 ---
 title: Research
 date: 2022-09-10 14:17:52
+excerpt: "SymbioticLab research themes"
 ---
 
 SymbioticLab focuses on *large-scale data systems* that can yield order-of-magnitude performance and efficiency improvements.


### PR DESCRIPTION
<img width="602" alt="Screen Shot 2023-10-23 at 11 53 35 PM" src="https://github.com/SymbioticLab/SymbioticLab.github.io/assets/29395896/04e9bed0-ae2a-4f97-8d18-2d7c4e640516">

Sharing a link to a page in our homepage looked like the above because Hexo automatically takes the first 200 words from each post to generate the `og:description` meta tag, which platforms like Slack, LinkedIn, Twitter, etc read to produce preview text.

Now the `excerpt` front matter in each page will replace preview text, instead of throwing up some bulk of text from the post.