### PR TITLE
Fix YAML quotes in Perseus news

### DIFF
--- a/source/_posts/Perseus-Accepted-to-Appear-at-SOSP-24-Congrats-Jae-Won-Yile-Insu-and-Luoxi.md
+++ b/source/_posts/Perseus-Accepted-to-Appear-at-SOSP-24-Congrats-Jae-Won-Yile-Insu-and-Luoxi.md
@@ -1,5 +1,5 @@
 ---
-title: 'Perseus Accepted to Appear at SOSP'24. Congrats Jae-Won, Yile, Insu, and Luoxi!'
+title: Perseus Accepted to Appear at SOSP'24. Congrats Jae-Won, Yile, Insu, and Luoxi!
 categories:
   - News
 date: 2024-08-05 21:29:55


### PR DESCRIPTION
This failed the build process. That's why the news item still didn't appear in the deployed homepage.