### PR TITLE
Patch OSS Page Script

### DIFF
--- a/custom/layouts/_scripts/index.njk
+++ b/custom/layouts/_scripts/index.njk
@@ -5,10 +5,6 @@
   {{- next_js('motion.js') }}
 {%- endif %}
 
-{%- if theme.scheme === 'Muse' or theme.scheme === 'Mist' %}
-  {{- next_js('schemes/muse.js') }}
-{%- endif %}
-
 {{- next_js('next-boot.js') }}
 {%- if theme.bookmark.enable %}
   {{- next_js('bookmark.js') }}

--- a/custom/layouts/_scripts/pjax.njk
+++ b/custom/layouts/_scripts/pjax.njk
@@ -24,9 +24,70 @@ document.addEventListener('pjax:success', () => {
       .add(NexT.motion.middleWares.postList)
       .bootstrap();
   }
-  const hasTOC = document.querySelector('.post-toc');
-  document.querySelector('.sidebar-inner').classList.toggle('sidebar-nav-active', hasTOC);
-  document.querySelector(hasTOC ? '.sidebar-nav-toc' : '.sidebar-nav-overview').click();
   NexT.utils.updateSidebarPosition();
 });
+
+// Create a persistent cache object for OSS page repos
+if (!window.githubDataCache) {
+  window.githubDataCache = {};
+}
+
+// A hook for fetching and loading data for OSS page
+// Function to update project information from GitHub API
+function updateProjectsFromGitHub() {
+  // Check if we're on the Open Source page
+  if (document.title !== "Open Source") {
+    return;
+  }
+
+  const projects = document.querySelectorAll('.project');
+
+  projects.forEach(project => {
+    const githubUrl = project.getAttribute('data-repo');
+    if (!githubUrl) return;
+
+    // Construct the GitHub API URL
+    const apiUrl = githubUrl.replace('https://github.com/', 'https://api.github.com/repos/');
+    
+    // Use project name or the full URL as a cache key
+    const cacheKey = githubUrl;
+    
+    if (window.githubDataCache[cacheKey]) {
+      // Use cached data if available
+      updateProjectDOM(project, window.githubDataCache[cacheKey]);
+    } else {
+      // Fetch from API if not in cache
+      fetch(apiUrl)
+        .then(response => response.json())
+        .then(data => {
+          // Store in cache
+          window.githubDataCache[cacheKey] = data;
+          // Update DOM
+          updateProjectDOM(project, data);
+        })
+        .catch(error => console.error('Error fetching GitHub data:', error));
+    }
+  });
+}
+
+// Helper function to update the DOM for a project
+function updateProjectDOM(project, data) {
+  // Use project name to generate IDs
+  const idPrefix = data.name.toLowerCase().replace(/ /g, '-');
+
+  const languageElement = document.getElementById(`${idPrefix}-language`);
+  const starsElement = document.getElementById(`${idPrefix}-stars`);
+  const forksElement = document.getElementById(`${idPrefix}-forks`);
+
+  // Only update if elements exist
+  if (languageElement) languageElement.textContent = data.language || 'N/A';
+  if (starsElement) starsElement.textContent = data.stargazers_count || 0;
+  if (forksElement) forksElement.textContent = data.forks_count || 0;
+}
+
+// Hook into pjax:success event
+document.addEventListener('pjax:success', updateProjectsFromGitHub);
+
+// Also run on initial page load to handle direct navigation
+updateProjectsFromGitHub();
 </script>

--- a/custom/layouts/open-source.njk
+++ b/custom/layouts/open-source.njk
@@ -16,7 +16,6 @@
     margin: 0;
     padding: 0;
   }
-
   .project {
     width: 48%; /* Full width for each project */
     padding: 15px;
@@ -33,35 +32,45 @@
     flex-direction: column;
     gap: 10px;
   }
-
   .project:hover {
     cursor: pointer;
     border-color: #bbb;
   }
-
   .project-header {
     display: flex;
     align-items: center;
     justify-content: space-between;
     margin-bottom: 10px;
   }
-
+  .logo-container {
+    width: 120px;
+    height: 50px;
+    display: flex;
+    align-items: center;
+    justify-content: flex-end; /* Right align the logo */
+    flex-shrink: 0; /* Prevent logo container from shrinking */
+    margin-left: 10px; /* Add some space between text and logo */
+  }
   .project-logo {
-    max-height: 50px;
+    max-width: 100%;
+    max-height: 100%;
     object-fit: contain;
-    margin-right: 2px;
   }
 
+  .project-info {
+    flex-grow: 1;
+    overflow: hidden; /* Prevent text from overflowing */
+  }
   .project-name {
     font-size: 20px;
     font-weight: bold;
-    flex-grow: 1;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
   }
-
   .project-description {
     font-size: 14px;
   }
-
   .project-details {
     display: flex;
     justify-content: flex-start;
@@ -69,33 +78,41 @@
     font-size: 12px;
     color: #666;
   }
-
   /* Fixed widths for consistent vertical alignment */
   .project-details .language {
     width: 50px; /* Fixed width for language */
   }
-
-  .project-details .stars, .project-details .forks {
+  .project-details .stars {
     width: 30px; /* Fixed width for stars and forks */
   }
-
+  .project-details .forks {
+    width: 30px; /* Fixed width for stars and forks */
+    justify-content: flex-start;
+  }
   .project-details span {
     display: flex;
     align-items: center;
     gap: 5px;
     justify-content: space-between;
   }
-
+  /* Only change the styles for the fork count text */
+  .project-details .forks span {
+    justify-content: flex-start; /* Left-align the text */
+    padding-left: 2px; /* Add a bit of padding */
+  }
+  .project-details .forks span span {
+    text-align: left;
+  }
   .project-details i {
     color: #333;
+    width: 12px; /* Fixed width for icons */
+    text-align: center; /* Center the icon */
   }
-
   @media (max-width: 800px) {
     .project {
       width: calc(100% - 20px); /* Full width on smaller screens */
       margin: 0 auto;
     }
-
     /* Remove fixed widths on smaller screens for flexibility */
     .project-details .language,
     .project-details .stars,
@@ -116,27 +133,26 @@
     {% if section.description %}
       <p>{{ section.description }}</p>
     {% endif %}
-
     <div class="project-container">
       {% for item in section.items %}
         <a href="{{ item.url or item.github_url }}" class="project" data-repo="{{ item.github_url }}">
           <div class="project-header">
-          <span>
-            <div class="project-name">{{ item.name }}</div>
-          {% if item.github_url %}
-            <div class="project-details">
-              <!-- Fixed width for consistent alignment, using FontAwesome icons -->
-              <span class="language"><i class="fas fa-code"></i> <span id="{{ item.name | lower | replace(' ', '-') }}-language">...</span></span>
-              <span class="stars"><i class="far fa-star"></i> <span id="{{ item.name | lower | replace(' ', '-') }}-stars">...</span></span>
-              <span class="forks"><i class="fas fa-code-branch"></i> <span id="{{ item.name | lower | replace(' ', '-') }}-forks">...</span></span>
+            <div class="project-info">
+              <div class="project-name">{{ item.name }}</div>
+              {% if item.github_url %}
+                <div class="project-details">
+                  <!-- Fixed width for consistent alignment, using FontAwesome icons -->
+                  <span class="language"><i class="fas fa-code"></i> <span id="{{ item.name | lower | replace(' ', '-') }}-language">...</span></span>
+                  <span class="stars"><i class="far fa-star"></i> <span id="{{ item.name | lower | replace(' ', '-') }}-stars">...</span></span>
+                  <span class="forks"><i class="fas fa-code-branch"></i> <span id="{{ item.name | lower | replace(' ', '-') }}-forks">...</span></span>
+                </div>
+              {% endif %}
             </div>
-          {% endif %}
-          </span>
-          {% if item.logo %}
-            <span style="width: {{ item.logo_scale or '100%' }}">
-              <img src="{{ item.logo }}" alt="{{ item.name }} logo" class="project-logo">
-            </span>
-          {% endif %}
+            {% if item.logo %}
+              <div class="logo-container">
+                <img src="{{ item.logo }}" alt="{{ item.name }} logo" class="project-logo">
+              </div>
+            {% endif %}
           </div>
           <div class="project-description">{{ item.description }}</div>
         </a>

--- a/custom/layouts/open-source.njk
+++ b/custom/layouts/open-source.njk
@@ -145,30 +145,4 @@
   </section>
 {% endfor %}
 
-<script src="https://kit.fontawesome.com/a076d05399.js" crossorigin="anonymous"></script> <!-- FontAwesome Kit -->
-<script>
-  document.addEventListener('DOMContentLoaded', function () {
-    const projects = document.querySelectorAll('.project');
-
-    projects.forEach(project => {
-      const githubUrl = project.getAttribute('data-repo');
-      if (githubUrl) {
-        // Construct the GitHub API URL by inserting "api." after "https://"
-        const apiUrl = githubUrl.replace('https://github.com/', 'https://api.github.com/repos/');
-
-        fetch(apiUrl)
-          .then(response => response.json())
-          .then(data => {
-            // Use project name to generate IDs
-            const idPrefix = data.name.toLowerCase().replace(/ /g, '-');
-
-            document.getElementById(`${idPrefix}-language`).textContent = data.language || 'N/A';
-            document.getElementById(`${idPrefix}-stars`).textContent = data.stargazers_count || 0;
-            document.getElementById(`${idPrefix}-forks`).textContent = data.forks_count || 0;
-          })
-          .catch(error => console.error('Error fetching GitHub data:', error));
-      }
-    });
-  });
-</script>
 {% endblock %}


### PR DESCRIPTION
The previous script will not load the Github repo status if a user first lands on another page and then navigates to the OSS page. This PR fixes that. Additionally, this patch avoids re-fetching repo data among back-and-forth navigations.

There is no style change.