### PR TITLE
OSS page: Reduce GitHub stat gap on small screens

### DIFF
--- a/custom/layouts/open-source.njk
+++ b/custom/layouts/open-source.njk
@@ -78,6 +78,11 @@
     font-size: 12px;
     color: #666;
   }
+  @media (max-width: 400px) {
+    .project-details {
+      gap: 10px;
+    }
+  }
   /* Fixed widths for consistent vertical alignment */
   .project-details .language {
     width: 50px; /* Fixed width for language */


### PR DESCRIPTION
Further fixes #303 

I tested this on devices on the Chrome dev tool. 400 px is the width where the logo starts overlapping with GitHub stats (particularly the number of forks).